### PR TITLE
Fix domain.nx attribute

### DIFF
--- a/Add Energy/add_energy.py
+++ b/Add Energy/add_energy.py
@@ -6,6 +6,10 @@ import time
 class domain:
     def __init__(self,Xpts, X0, Xf, dt, T0, Tf, totsnaps, Gamma_0, kappa_0, beta):
         self._Xpts = Xpts
+        # Many helper classes refer to the number of grid points via the
+        # attribute ``nx``.  Define it here to avoid ``AttributeError`` when
+        # those routines access ``domain.nx``.
+        self.nx = Xpts
         self._X0 = X0
         self._Xf = Xf
         self._dt = dt

--- a/Add Energy/oop_code.py
+++ b/Add Energy/oop_code.py
@@ -6,6 +6,12 @@ import time
 class domain:
     def __init__(self, Xpts, X0, Xf, dt, T0, Tf, totsnaps, Gamma_0, kappa_0, beta):
         self.Xpts = Xpts
+        # Some parts of the code expect the grid size to be stored in an
+        # attribute named ``nx``.  The original implementation did not define
+        # this attribute which resulted in ``AttributeError`` exceptions when
+        # ``domain.nx`` was accessed.  Provide the alias here so both names can
+        # be used interchangeably.
+        self.nx = Xpts
         self.X0 = X0
         self.Xf = Xf
         self.dt = dt


### PR DESCRIPTION
## Summary
- prevent AttributeError for `domain.nx` by defining the alias in both domain classes

## Testing
- `python -m py_compile 'Add Energy/oop_code.py' 'Add Energy/add_energy.py'`

------
https://chatgpt.com/codex/tasks/task_e_683f71f20d188332b87b434fe77853da